### PR TITLE
fixed and wrote test case to catch error

### DIFF
--- a/items/serializers/item_serializer.py
+++ b/items/serializers/item_serializer.py
@@ -23,8 +23,9 @@ class ItemSerializer(serializers.ModelSerializer):
         try:
             tags_data = validated_data.pop('tags')
             item = Item.objects.create(**validated_data)
-            for tag in tags_data:
-                Tag.objects.create(item=item, **tag)
+            if tags_data is not None:
+                for tag in tags_data:
+                    Tag.objects.create(item=item, **tag)
         except KeyError:
             item = Item.objects.create(**validated_data)
         username = self.context['request'].user.username

--- a/items/tests/test_item_api.py
+++ b/items/tests/test_item_api.py
@@ -24,8 +24,9 @@ def equal_item(test_client, item_json, item_id):
     test_client.assertEqual(item_json.get('model_number'), item.model_number)
     test_client.assertEqual(item_json.get('description'), item.description)
     test_client.assertEqual(item_json.get('location'), item.location)
-    test_client.assertEqual([tagItem['tag'] for tagItem in item_json.get('tags', [])],
-                            [tag_item.tag for tag_item in item.tags.all()])
+    if item_json.get('tags') is not None:
+        test_client.assertEqual([tagItem['tag'] for tagItem in item_json.get('tags', [])],
+                                [tag_item.tag for tag_item in item.tags.all()])
 
 
 class GetItemTestCase(APITestCase):
@@ -106,6 +107,16 @@ class PostItemTestCase(APITestCase):
         self.client.force_authenticate(user=self.admin, token=self.tok)
         url = reverse('item-list')
         data = {'name': 'Arduino Uno', 'quantity': 3}
+        self.client.login(username=USERNAME, password=PASSWORD)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        json_item = json.loads(str(response.content, 'utf-8'))
+        equal_item(self, data, json_item.get('id'))
+
+    def test_post_items_with_null_tags(self):
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse('item-list')
+        data = {'name': 'Hybrid Engine', 'quantity': 3, 'tags': None}
         self.client.login(username=USERNAME, password=PASSWORD)
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
@sunnyownage Found a bug :/ when putting in:-

POST /api/item/

{
	"name": "Flamethrower1245",
	"quantity": 3,
	"model_number": null,
	"description": null,
	"location": null,
	"tags": null
}

null tags cause the system to do a NoneType Error. Fixed now 💃 