### PR TITLE
Oauth

### DIFF
--- a/inventoryProject/dukeAuth.py
+++ b/inventoryProject/dukeAuth.py
@@ -1,0 +1,37 @@
+from urllib.parse import urljoin
+
+from social_core.backends.oauth import BaseOAuth2
+
+
+class DukeOAuth2(BaseOAuth2):
+    """Duke OAuth2 authentication backend"""
+
+    def auth_html(self):
+        pass
+
+    name = 'duke'
+    API_URL = "https://api.colab.duke.edu/"
+    AUTHORIZATION_URL = 'https://oauth.oit.duke.edu/oauth/authorize'
+    ACCESS_TOKEN_URL = 'https://oauth.oit.duke.edu/oauth/token'
+    ACCESS_TOKEN_METHOD = 'POST'
+    ID_KEY = 'netid'
+    REDIRECT_STATE = False
+    EXTRA_DATA = [
+        ('expires_in', 'expires_in')
+    ]
+
+    def get_user_details(self, response):
+        """Return user details from Duke account"""
+        return {'username': response.get('netid'),
+                'email': response.get('mail'),
+                'first_name': response.get('firstName'),
+                'last_name': response.get('lastName')}
+
+    def user_data(self, access_token, *args, **kwargs):
+        data = self._user_data(access_token)
+        return data
+
+    def _user_data(self, access_token, path=None):
+        url = urljoin(self.API_URL, 'identity/v1/')
+        client_id, client_secret = self.get_key_and_secret()
+        return self.get_json(url, headers={'x-api-key': client_id, 'Authorization': 'Bearer ' + access_token})

--- a/inventoryProject/settings/default.py
+++ b/inventoryProject/settings/default.py
@@ -50,8 +50,24 @@ INSTALLED_APPS = [
     'inventory_disbursements.apps.InventoryDisbursementsConfig',
     'items.fixtures',
     'oauth2_provider',
+    'social_django',
+    'rest_framework_social_oauth2',
     'corsheaders',
 ]
+
+# SOCIAL_AUTH_DUKE_AUTH_EXTRA_ARGUMENTS = {'scope': 'basic identity:netid:read'}
+SOCIAL_AUTH_DUKE_KEY = 'asap-inventory-system'
+SOCIAL_AUTH_DUKE_SECRET = '4VBvMIAw*KA5oL7EnoG8aLYY=*Tnrmb9o$$+Gqyxe$LYf@skQL'
+SOCIAL_AUTH_DUKE_SCOPE = ['basic', 'identity:netid:read']
+
+DRFSO2_PROPRIETARY_BACKEND_NAME = 'duke'
+
+
+
+AUTHENTICATION_BACKENDS = (
+    'inventoryProject.dukeAuth.DukeOAuth2',
+    'django.contrib.auth.backends.ModelBackend'
+)
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
@@ -83,7 +99,8 @@ CORS_ALLOW_METHODS = (
 
 OAUTH2_PROVIDER = {
     # this is the list of available scopes
-    'SCOPES': {'read': 'Read scope', 'write': 'Write scope', 'groups': 'Access to your groups'}
+    'SCOPES': {'read': 'Read scope', 'write': 'Write scope', 'groups': 'Access to your groups'},
+    'ACCESS_TOKEN_EXPIRE_SECONDS': 3600
 }
 
 ROOT_URLCONF = 'inventoryProject.urls'
@@ -100,6 +117,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },
@@ -156,6 +175,7 @@ REST_FRAMEWORK = {
     'SEARCH_PARAM': "search",
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        'rest_framework_social_oauth2.authentication.SocialAuthentication',
     )
 }
 

--- a/inventoryProject/urls.py
+++ b/inventoryProject/urls.py
@@ -29,5 +29,6 @@ urlpatterns = [
     url(r'^api/user/', include('inventory_user.urls')),
     url(r'^api/log/', include('inventory_logger.urls')),
     url(r'^api/disburse/', include('inventory_disbursements.urls')),
-    url(r'^api/o/', include('oauth2_provider.urls', namespace='oauth2_provider'))
+    url(r'^api/o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    url(r'^auth/', include('rest_framework_social_oauth2.urls')),
 ]

--- a/inventory_user/serializers/user_serializer.py
+++ b/inventory_user/serializers/user_serializer.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'username', 'password', 'email', 'is_staff', 'last_login', 'date_joined')
+        fields = ('id', 'username', 'password', 'email', 'is_staff', 'is_superuser', 'last_login', 'date_joined')
         read_only_fields = ('last_login', 'date_joined')
         extra_kwargs = {'password': {'write_only': True}}
 
@@ -14,10 +14,9 @@ class UserSerializer(serializers.ModelSerializer):
         password = validated_data.get('password')
         email = validated_data.get('email')
         is_staff = validated_data.get('is_staff')
-        if is_staff:
-            return User.objects.create_superuser(username=username, password=password, email=email)
-        else:
-            return User.objects.create_user(username=username, password=password, email=email)
+        is_superuser = validated_data.get('is_superuser')
+        return User.objects.create_superuser(username=username, password=password, email=email) if is_superuser \
+            else User.objects.create(username=username, password=password, email=email, is_staff=is_staff)
 
 
 class LargeUserSerializer(serializers.ModelSerializer):

--- a/inventory_user/urls.py
+++ b/inventory_user/urls.py
@@ -1,10 +1,12 @@
 from django.conf.urls import url
 
-from inventory_user.views.user_view import InventoryUserList, InventoryCurrentUser, InventoryUser, LargeUserList
+from inventory_user.views.user_view import InventoryUserList, InventoryCurrentUser, InventoryUser, LargeUserList, \
+    get_duke_access_token
 
 urlpatterns = [
     url(r'^$', InventoryUserList.as_view(), name='user-list'),
     url(r'^large/$', LargeUserList.as_view(), name='large-user-list'),
     url(r'^current/$', InventoryCurrentUser.as_view(), name='user-current'),
     url(r'^(?P<pk>[0-9]+)$', InventoryUser.as_view(), name='user-detail'),
+    url(r'^auth/duke$', get_duke_access_token, name='auth-duke')
 ]

--- a/inventory_user/views/user_view.py
+++ b/inventory_user/views/user_view.py
@@ -1,13 +1,19 @@
+import requests
 from django.contrib.auth.models import User
 from oauth2_provider.ext.rest_framework import TokenHasReadWriteScope
 from rest_framework import filters
 from rest_framework import generics
+from rest_framework.decorators import api_view
+from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 
 from inventoryProject.permissions import IsAdminOrReadOnly
 from inventory_user.serializers.user_serializer import UserSerializer, LargeUserSerializer
 from items.custom_pagination import LargeResultsSetPagination
+
+from django.conf import settings
+import json
 
 
 class InventoryUserList(generics.ListCreateAPIView):
@@ -39,5 +45,25 @@ class LargeUserList(generics.ListAPIView):
     pagination_class = LargeResultsSetPagination
     filter_backends = (filters.SearchFilter,)
     search_fields = ('username', )
+
+
+@api_view(['POST'])
+def get_duke_access_token(request):
+    if request.method == 'POST':
+        code = request.data.get('code')
+        redirect_uri = request.data.get('redirect_uri')
+        if code is None or redirect_uri is None:
+            raise ParseError(detail='Require code and redirect_uri in body')
+        data = {
+            'grant_type': 'authorization_code',
+            'client_id': settings.SOCIAL_AUTH_DUKE_KEY,
+            'client_secret': settings.SOCIAL_AUTH_DUKE_SECRET,
+            'code': code,
+            'redirect_uri': redirect_uri
+        }
+        response = requests.post(url='https://oauth.oit.duke.edu/oauth/token', data=data)
+        return Response(data=response.json())
+
+
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ html5lib==0.999
 psycopg2==2.6.2
 django-cors-middleware==1.3.1
 django-oauth-toolkit==0.11.0
+social-auth-app-django==1.0.1
+social-auth-core==1.1.0
+django-rest-framework-social-oauth2==1.0.5


### PR DESCRIPTION
Flow for users to log in through NetID:-

1. Frontend should redirect to this link
```json
https://oauth.oit.duke.edu/oauth/authorize?response_type=code&redirect_uri=<redirect_uri>&client_id=asap-inventory-system&scope=basic+identity%3Anetid%3Aread&state=<randomly_generated_state>
```
Redirect_uri is a url where the oauth will redirect to on success or fail. If success, the auth_token will be appended to the url parameter

2. Convert the auth_token to a Duke Access_token
POST /api/user/auth/duke HTTP/1.1
Host: localhost:8000 <--note it is our own server
Content-Type: application/json

Request:
```json
    {
      "code":"<auth_token>",
      "redirect_uri":"<redirect_uri>"
    }
```

Response:
```json
{
  "access_token": "<duke_access_token>",
  "token_type": "Bearer",
  "refresh_token": "<refresh_token>",
  "expires_in": 3600,
  "scope": "basic identity:netid:read"
}
```

3. Convert the Duke OAuth token to a ASAP_Inventory Oauth Token to use ASAP API's
POST /auth/convert-token HTTP/1.1
Host: localhost:8000
Content-Type: application/x-www-form-urlencoded
Request:
```
grant_type=convert_token&client_id=OCMIHNG0WSjC3679oo6LpgMMy0iucOQRoxDGsQ1F&backend=duke&token=<duke_access_token>
```

Response:
```json
{
  "access_token": "<access_token>",
  "expires_in": 3600,
  "refresh_token": "<refresh_token>",
  "scope": "read groups write",
  "token_type": "Bearer"
}
```

Now you can use the asap_access_token and append it to the api calls like the old way
Authorization: "Bearer <access_token>"
