### PR TITLE
added api-key support for tokens

### DIFF
--- a/inventoryProject/permissions.py
+++ b/inventoryProject/permissions.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions
+from rest_framework.compat import is_authenticated
 
 
 class IsAdminOrReadOnly(permissions.BasePermission):
@@ -7,7 +8,7 @@ class IsAdminOrReadOnly(permissions.BasePermission):
         # Read permissions are allowed to any request,
         # so we'll always allow GET, HEAD or OPTIONS requests.
         if request.method in permissions.SAFE_METHODS:
-            return True
+            return is_authenticated(request.user)
 
         # The user has to be a staff
-        return request.user.is_staff
+        return is_authenticated(request.user) and request.user.is_staff

--- a/inventoryProject/settings/default.py
+++ b/inventoryProject/settings/default.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'oauth2_provider',
     'social_django',
     'rest_framework_social_oauth2',
+    'rest_framework.authtoken',
     'corsheaders',
 ]
 
@@ -176,6 +177,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.ext.rest_framework.OAuth2Authentication',
         'rest_framework_social_oauth2.authentication.SocialAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
     )
 }
 

--- a/inventory_disbursements/views/disbursement_view.py
+++ b/inventory_disbursements/views/disbursement_view.py
@@ -9,7 +9,7 @@ from items.models import Item
 
 
 class DisbursementList(generics.ListCreateAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     serializer_class = DisbursementSerializer
 
     def get_queryset(self):

--- a/inventory_logger/views/action_view.py
+++ b/inventory_logger/views/action_view.py
@@ -7,7 +7,7 @@ from inventory_logger.serializers.log_serializer import ActionSerializer
 
 
 class ActionList(generics.ListCreateAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Action.objects.all()
     serializer_class = ActionSerializer
     paginate_by = None

--- a/inventory_logger/views/log_view.py
+++ b/inventory_logger/views/log_view.py
@@ -8,7 +8,7 @@ from inventory_logger.serializers.log_serializer import LogSerializer
 
 
 class LogList(generics.ListCreateAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Log.objects.all()
     serializer_class = LogSerializer
     filter_backends = (DjangoFilterBackend, )

--- a/inventory_user/urls.py
+++ b/inventory_user/urls.py
@@ -1,12 +1,13 @@
 from django.conf.urls import url
 
 from inventory_user.views.user_view import InventoryUserList, InventoryCurrentUser, InventoryUser, LargeUserList, \
-    get_duke_access_token
+    get_duke_access_token, get_api_token
 
 urlpatterns = [
     url(r'^$', InventoryUserList.as_view(), name='user-list'),
     url(r'^large/$', LargeUserList.as_view(), name='large-user-list'),
     url(r'^current/$', InventoryCurrentUser.as_view(), name='user-current'),
     url(r'^(?P<pk>[0-9]+)$', InventoryUser.as_view(), name='user-detail'),
-    url(r'^auth/duke$', get_duke_access_token, name='auth-duke')
+    url(r'^auth/duke$', get_duke_access_token, name='auth-duke'),
+    url(r'^auth/token', get_api_token, name='auth-api')
 ]

--- a/items/views/field_view.py
+++ b/items/views/field_view.py
@@ -1,4 +1,3 @@
-from oauth2_provider.ext.rest_framework import TokenHasReadWriteScope
 from rest_framework import generics
 from rest_framework.permissions import IsAdminUser
 
@@ -9,37 +8,37 @@ from items.serializers.field_serializer import FieldSerializer, IntFieldSerializ
 
 class FieldList(generics.ListCreateAPIView):
     queryset = Field.objects.all()
-    permission_classes = [IsAdminUser, TokenHasReadWriteScope]
+    permission_classes = [IsAdminUser]
     serializer_class = FieldSerializer
 
 
 class FieldDeletion(generics.DestroyAPIView):
     queryset = Field.objects.all()
-    permission_classes = [IsAdminUser, TokenHasReadWriteScope]
+    permission_classes = [IsAdminUser]
     serializer_class = FieldSerializer
 
 
 class IntFieldUpdate(generics.UpdateAPIView):
     queryset = IntField.objects.all()
-    permission_classes = [IsAdminUser, TokenHasReadWriteScope]
+    permission_classes = [IsAdminUser]
     serializer_class = IntFieldSerializer
 
 
 class FloatFieldUpdate(generics.UpdateAPIView):
     queryset = FloatField.objects.all()
-    permission_classes = [IsAdminUser, TokenHasReadWriteScope]
+    permission_classes = [IsAdminUser]
     serializer_class = FloatFieldSerializer
 
 
 class ShortTextFieldUpdate(generics.UpdateAPIView):
     queryset = ShortTextField.objects.all()
-    permission_classes = [IsAdminUser, TokenHasReadWriteScope]
+    permission_classes = [IsAdminUser]
     serializer_class = ShortTextFieldSerializer
 
 
 class LongTextFieldUpdate(generics.UpdateAPIView):
     queryset = LongTextField.objects.all()
-    permission_classes = [IsAdminUser, TokenHasReadWriteScope]
+    permission_classes = [IsAdminUser]
     serializer_class = LongTextFieldSerializer
 
 

--- a/items/views/item_view.py
+++ b/items/views/item_view.py
@@ -1,4 +1,3 @@
-from oauth2_provider.ext.rest_framework import TokenHasReadWriteScope
 from rest_framework import filters
 from rest_framework import generics
 
@@ -13,7 +12,7 @@ from items.serializers.item_serializer import ItemSerializer, UniqueItemSerializ
 
 
 class ItemList(generics.ListCreateAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     serializer_class = ItemSerializer
     filter_backends = (filters.SearchFilter,)
     search_fields = ('name', 'model_number', 'tags__tag')
@@ -30,7 +29,7 @@ class ItemList(generics.ListCreateAPIView):
 
 
 class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Item.objects.all()
     serializer_class = DetailedItemSerializer
 
@@ -42,7 +41,7 @@ class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class UniqueItemList(generics.ListAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Item.objects.all().values('id', 'name').distinct()
     serializer_class = UniqueItemSerializer
     pagination_class = LargeResultsSetPagination

--- a/items/views/tag_view.py
+++ b/items/views/tag_view.py
@@ -1,4 +1,3 @@
-from oauth2_provider.ext.rest_framework import TokenHasReadWriteScope
 from rest_framework import filters
 from rest_framework import generics
 
@@ -10,17 +9,17 @@ from items.serializers.tag_serializer import TagSerializer, TagSingleSerializer
 
 class TagList(generics.CreateAPIView):
     queryset = Tag.objects.all()
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     serializer_class = TagSerializer
 
 
 class TagDeletion(generics.DestroyAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Tag.objects.all()
 
 
 class UniqueTagList(generics.ListAPIView):
-    permission_classes = [IsAdminOrReadOnly, TokenHasReadWriteScope]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Tag.objects.all().values('tag').distinct()
     serializer_class = TagSingleSerializer
     pagination_class = LargeResultsSetPagination


### PR DESCRIPTION
Gets a new api-key or returns the old one 🗡 

@ankitkayastha please remove TokenHasReadWriteScope from permissions for requests (was worried about massive merge conflicts), the updated IsAdminOrReadOnlyhandles this case :D

GET /api/user/auth/token HTTP/1.1
Host: localhost:8000
Content-Type: application/json
Authorization: Bearer <access_token>

Response:
```json
{
  "token": "<alphanumeric_tokenz>"
}
```


In order to use:-
Do a header for:-
Authorization: Token <token_here>