### PR TITLE
Adding log instances items

### DIFF
--- a/items/serializers/item_serializer.py
+++ b/items/serializers/item_serializer.py
@@ -1,4 +1,6 @@
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
+from rest_framework.exceptions import NotFound, MethodNotAllowed, ParseError
 
 from inventory_logger.action_enum import ActionEnum
 from inventory_logger.utility.logger import LoggerUtility
@@ -40,4 +42,34 @@ class ItemSerializer(serializers.ModelSerializer):
         username = self.context['request'].user.username
         LoggerUtility.log_as_system(ActionEnum.ITEM_CREATED, username + " Created New Item:" + item.__str__())
         return item
+
+
+class ItemQuantitySerializer(serializers.Serializer):
+    item_id = serializers.IntegerField(required=True)
+    quantity = serializers.IntegerField(required=True)
+    comment = serializers.CharField(required=False)
+
+    def create(self, validated_data):
+        user = self.context['request'].user
+        try:
+            item = Item.objects.get(pk=validated_data.get('item_id'))
+        except ObjectDoesNotExist:
+            raise NotFound(detail="Item is not found in Database")
+        quantity = validated_data.get('quantity', 0)
+        comment = validated_data.get('comment', "No Comment")
+        if quantity < 0:
+            # TODO: log destruction here later with comments
+            print('LOG DESTRUCTION' + comment)
+        elif quantity > 0:
+            # TODO: log accquisition here later with comments
+            print('LOG ACCQUISITION' + comment)
+        else:
+            raise ParseError(detail="Quantity must be a nonzero value")
+        item.quantity = item.quantity + quantity
+        item.save()
+        return item
+
+    def update(self, instance, validated_data):
+        raise MethodNotAllowed(detail="Update is not allowed", method=self.update)
+
 

--- a/items/tests/test_item_api.py
+++ b/items/tests/test_item_api.py
@@ -215,6 +215,31 @@ class UpdateItemTestCase(APITestCase):
         item = Item.objects.get(pk=json.loads(str(response.content, 'utf-8')).get('id'))
         self.assertEqual(data.get('name'), item.name)
 
+    def test_log_addition_acquisitions_item_not_found(self):
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse(viewname='item-quantity-modification')
+        data = {'item_id': 10234, 'quantity': 10}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_log_addition_acquisitions_quantity_is_zero(self):
+        item = Item.objects.create(name='Replication gun', quantity=100)
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse(viewname='item-quantity-modification')
+        data = {'item_id': item.id, 'quantity': 0}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_log_addition_acquisitions(self):
+        item = Item.objects.create(name='Magnetic Accelerated Cannon', quantity=100)
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse(viewname='item-quantity-modification')
+        data = {'item_id': item.id, 'quantity': 10}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        updated_item = Item.objects.get(pk=item.id)
+        self.assertEqual(updated_item.quantity, item.quantity + data.get('quantity'))
+
 
 class DeleteItemTestCase(APITestCase):
         def setUp(self):

--- a/items/urls.py
+++ b/items/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from items.views.field_view import FieldList, FieldDeletion, IntFieldUpdate, FloatFieldUpdate, ShortTextFieldUpdate, \
     LongTextFieldUpdate
-from items.views.item_view import ItemList, ItemDetail, UniqueItemList
+from items.views.item_view import ItemList, ItemDetail, UniqueItemList, ItemQuantityModification
 from items.views.tag_view import TagDeletion, TagList, UniqueTagList
 
 urlpatterns = [
@@ -18,4 +18,5 @@ urlpatterns = [
     url(r'^field/float/(?P<pk>[0-9]+)$', FloatFieldUpdate.as_view(), name='float-field-update'),
     url(r'^field/short_text/(?P<pk>[0-9]+)$', ShortTextFieldUpdate.as_view(), name='short-text-field-update'),
     url(r'^field/long_text/(?P<pk>[0-9]+)$', LongTextFieldUpdate.as_view(), name='long-text-field-update'),
+    url(r'^quantity$', ItemQuantityModification.as_view(), name='item-quantity-modification'),
 ]


### PR DESCRIPTION
1. Log Acquisition of Items
POST /api/item/quantity HTTP/1.1
Host: localhost:8000
Content-Type: application/json
Authorization: Bearer <access_token>

The quantity value is the amount of items gained or loss (in negative). Not the new Item Quantity
Item.quantity = Item.quantity + quantity

Request:
```json
    {
      "item_id": 6,
      "quantity": 5,
      "comment": "They gave it to us for fwee"
    }
```

Response:
```json
{
  "id": 6,
  "name": "Fire Phone",
  "quantity": 10,
  "model_number": null,
  "description": null,
  "tags": []
}
```

Now staff is not able to add the quantities