### PR TITLE
added disbursement fix for quantity and retrive view

### DIFF
--- a/inventory_disbursements/business_logic/quantity_logic.py
+++ b/inventory_disbursements/business_logic/quantity_logic.py
@@ -1,0 +1,13 @@
+from rest_framework.exceptions import ParseError, MethodNotAllowed
+
+
+def quantity_logic(quantity, item_quantity, method):
+    if quantity is None:
+        raise ParseError("Quantity must be specified")
+    if quantity == 0:
+        raise ParseError("Quantity cannot be 0")
+    if item_quantity < quantity:
+        detail = "Quantity disbursed {disbursed} cannot be greater than item quantity, {item_quantity}".format
+        raise MethodNotAllowed(detail=detail(disbursed=quantity,item_quantity=item_quantity),
+                               method=method)
+

--- a/items/tests/test_item_api.py
+++ b/items/tests/test_item_api.py
@@ -33,7 +33,6 @@ def equal_item(test_client, item_json, item_id):
 class GetItemTestCase(APITestCase):
     fixtures = ['item_action.json']
 
-
     def setUp(self):
         self.admin = User.objects.create_superuser(USERNAME, 'test@test.com', PASSWORD)
         self.application = Application(
@@ -104,7 +103,6 @@ class PostItemTestCase(APITestCase):
         )
         oauth2_settings._DEFAULT_SCOPES = ['read','write','groups']
 
-
     def test_post_items_with_tags(self):
         self.client.force_authenticate(user=self.admin, token=self.tok)
         url = reverse('item-list')
@@ -137,7 +135,6 @@ class PostItemTestCase(APITestCase):
 
 class UpdateItemTestCase(APITestCase):
     fixtures = ['item_action.json']
-
 
     def setUp(self):
         self.admin = User.objects.create_superuser(USERNAME, 'test@test.com', PASSWORD)
@@ -172,7 +169,6 @@ class UpdateItemTestCase(APITestCase):
         )
         oauth2_settings._DEFAULT_SCOPES = ['read','write','groups']
 
-
     def test_update_quantity_using_staff(self):
         self.client.force_authenticate(user=self.staff, token=self.staff_tok)
         item = Item.objects.get(pk=self.item_id)
@@ -185,7 +181,6 @@ class UpdateItemTestCase(APITestCase):
         item_updated = Item.objects.get(pk=self.item_id)
         self.assertEqual(item.name, item_updated.name)
         self.assertEqual(item.quantity, item_updated.quantity)
-
 
     def test_update_all_using_staff(self):
         self.client.force_authenticate(user=self.staff, token=self.staff_tok)


### PR DESCRIPTION
GET /api/disburse/6 HTTP/1.1
Host: localhost:8000
Content-Type: application/json
Authorization: Token <access_token>

Response:-
```json
{
  "id": 6,
  "disburser": {
    "id": 24,
    "username": "staff"
  },
  "receiver": {
    "id": 1,
    "username": "admin"
  },
  "comment": "lit",
  "disbursements": [
    {
      "id": 12,
      "item": {
        "id": 5,
        "name": "iPhone 7",
        "quantity": 44
      },
      "quantity": 5
    }
  ]
}
```