### PR TITLE
added the patch field to the custom fields to change name and type

### DIFF
--- a/items/urls.py
+++ b/items/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
-from items.views.field_view import FieldList, FieldDeletion, IntFieldUpdate, FloatFieldUpdate, ShortTextFieldUpdate, \
-    LongTextFieldUpdate
+from items.views.field_view import FieldList, IntFieldUpdate, FloatFieldUpdate, ShortTextFieldUpdate, \
+    LongTextFieldUpdate, FieldDetailed
 from items.views.item_view import ItemList, ItemDetail, UniqueItemList, ItemQuantityModification
 from items.views.tag_view import TagDeletion, TagList, UniqueTagList
 
@@ -13,7 +13,7 @@ urlpatterns = [
     url(r'^tag/(?P<pk>[0-9]+)$', TagDeletion.as_view(), name='tag-deletion'),
     url(r'^tag/unique/$', UniqueTagList.as_view(), name='unique-tag-list'),
     url(r'^field/$', FieldList.as_view(), name='field-list'),
-    url(r'^field/(?P<pk>[0-9]+)$', FieldDeletion.as_view(), name='field-deletion'),
+    url(r'^field/(?P<pk>[0-9]+)$', FieldDetailed.as_view(), name='field-detail'),
     url(r'^field/int/(?P<pk>[0-9]+)$', IntFieldUpdate.as_view(), name='int-field-update'),
     url(r'^field/float/(?P<pk>[0-9]+)$', FloatFieldUpdate.as_view(), name='float-field-update'),
     url(r'^field/short_text/(?P<pk>[0-9]+)$', ShortTextFieldUpdate.as_view(), name='short-text-field-update'),

--- a/items/views/field_view.py
+++ b/items/views/field_view.py
@@ -1,4 +1,5 @@
 from rest_framework import generics
+from rest_framework.exceptions import ParseError
 
 from inventoryProject.permissions import IsSuperUser, IsStaffUser
 from inventoryProject.utility.print_functions import serializer_pretty_print, serializer_compare_pretty_print
@@ -32,10 +33,15 @@ class FieldList(generics.ListCreateAPIView):
                           comment=comment)
 
 
-class FieldDeletion(generics.DestroyAPIView):
+class FieldDetailed(generics.RetrieveUpdateDestroyAPIView):
     queryset = Field.objects.all()
     permission_classes = [IsSuperUser]
     serializer_class = FieldSerializer
+
+    def perform_update(self, serializer):
+        if serializer.validated_data.get('type') is not None:
+            raise ParseError(detail='You cannot change the type of a field')
+        serializer.save()
 
     def perform_destroy(self, instance):
         field_serializer = FieldSerializer(instance=instance)


### PR DESCRIPTION
PATCH /api/item/field/<field_id>a HTTP/1.1
Host: localhost:8000
Content-Type: application/json
Authorization: Token <api-key>

Request:
{
	"name":"lit-o-meter",
	"private": false
}

Returns HTTP 200 OK on success.

Does not allow change in type