### PR TITLE
created loans with create loans, delete loans and return loans

### DIFF
--- a/inventory_requests/business_logic/loan_logic.py
+++ b/inventory_requests/business_logic/loan_logic.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from items.models import Item
+
+
+def return_loan_logic(loan):
+    if loan.returned_timestamp is None and loan.loaned_timestamp is not None:
+        loan.returned_timestamp = datetime.now()
+        loan.save()
+        item = Item.objects.get(pk=loan.item.id)
+        item.quantity = item.quantity + loan.quantity
+        item.save()
+        return True
+    return False

--- a/inventory_requests/business_logic/loan_logic.py
+++ b/inventory_requests/business_logic/loan_logic.py
@@ -3,12 +3,14 @@ from datetime import datetime
 from items.models import Item
 
 
-def return_loan_logic(loan):
+def return_loan_logic(loan, quantity=None):
     if loan.returned_timestamp is None and loan.loaned_timestamp is not None:
-        loan.returned_timestamp = datetime.now()
-        loan.save()
+        if quantity is None or quantity == loan.quantity:
+            loan.returned_timestamp = datetime.now()
+            loan.save()
+            quantity = loan.quantity
         item = Item.objects.get(pk=loan.item.id)
-        item.quantity = item.quantity + loan.quantity
+        item.quantity = item.quantity + quantity
         item.save()
         return True
     return False

--- a/inventory_requests/business_logic/modify_request_cart_logic.py
+++ b/inventory_requests/business_logic/modify_request_cart_logic.py
@@ -4,10 +4,9 @@ from inventoryProject.utility.queryset_functions import get_or_not_found
 from items.models import Item
 
 
-def precheck_item(request, modification_type):
+def precheck_item(request):
     item = get_or_not_found(Item, pk=request.item.id)
-    return not (item.quantity - request.quantity < 0 and
-                (modification_type == "approved" or modification_type == "disburse"))
+    return not item.quantity - request.quantity < 0
 
 
 def can_modify_cart_status(request):
@@ -15,10 +14,10 @@ def can_modify_cart_status(request):
                                                                            and request.status == "active")
 
 
-def can_approve_disburse_request_cart(request_cart_to_modify, modification_type):
-    disbursements = [precheck_item(request, modification_type) for
+def can_approve_disburse_request_cart(request_cart_to_modify):
+    disbursements = [precheck_item(request) for
                      request in request_cart_to_modify.cart_disbursements.all()]
-    loans = [precheck_item(request, modification_type) for request in request_cart_to_modify.cart_loans.all()]
+    loans = [precheck_item(request) for request in request_cart_to_modify.cart_loans.all()]
     return not(False in disbursements or False in loans) and can_modify_cart_status(request_cart_to_modify)
 
 

--- a/inventory_requests/business_logic/modify_request_cart_logic.py
+++ b/inventory_requests/business_logic/modify_request_cart_logic.py
@@ -11,7 +11,8 @@ def precheck_item(request, modification_type):
 
 
 def can_modify_cart_status(request):
-    return request.status == "outstanding" or (request.staff is not None and request.status == "active")
+    return (request.status == "outstanding" and request.staff is None) or (request.staff is not None
+                                                                           and request.status == "active")
 
 
 def can_approve_disburse_request_cart(request_cart_to_modify, modification_type):

--- a/inventory_requests/business_logic/modify_request_cart_logic.py
+++ b/inventory_requests/business_logic/modify_request_cart_logic.py
@@ -10,13 +10,15 @@ def precheck_item(request, modification_type):
                 (modification_type == "approved" or modification_type == "disburse"))
 
 
-def can_approve_deny_cancel_disburse_request_cart(request_cart_to_modify, modification_type):
+def can_modify_cart_status(request):
+    return request.status == "outstanding" or (request.staff is not None and request.status == "active")
+
+
+def can_approve_disburse_request_cart(request_cart_to_modify, modification_type):
     disbursements = [precheck_item(request, modification_type) for
                      request in request_cart_to_modify.cart_disbursements.all()]
     loans = [precheck_item(request, modification_type) for request in request_cart_to_modify.cart_loans.all()]
-    return not(False in disbursements or False in loans) and \
-        (request_cart_to_modify.status == "outstanding" or
-        (request_cart_to_modify.staff is not None and request_cart_to_modify.status == "active"))
+    return not(False in disbursements or False in loans) and can_modify_cart_status(request_cart_to_modify)
 
 
 def subtract_item(request):

--- a/inventory_requests/business_logic/modify_request_cart_logic.py
+++ b/inventory_requests/business_logic/modify_request_cart_logic.py
@@ -36,3 +36,7 @@ def start_loan(request):
     for loan in request.cart_loans.all():
         loan.loaned_timestamp = datetime.now()
         loan.save()
+
+
+def can_convert_request_type(cart, user):
+    return cart.status in ('fulfilled', 'outstanding', 'approved') and user.is_staff

--- a/inventory_requests/business_logic/modify_request_cart_logic.py
+++ b/inventory_requests/business_logic/modify_request_cart_logic.py
@@ -1,21 +1,36 @@
+from datetime import datetime
+
 from inventoryProject.utility.queryset_functions import get_or_not_found
 from items.models import Item
 
 
+def precheck_item(request, modification_type):
+    item = get_or_not_found(Item, pk=request.item.id)
+    return not (item.quantity - request.quantity < 0 and
+                (modification_type == "approved" or modification_type == "disburse"))
+
+
 def can_approve_deny_cancel_disburse_request_cart(request_cart_to_modify, modification_type):
-    for request in request_cart_to_modify.cart_disbursements.all():
-        item = get_or_not_found(Item, pk=request.item.id)
-        if item.quantity - request.quantity < 0 and (modification_type == "approved"
-                                                     or modification_type == "disburse"):
-            return False
-    return request_cart_to_modify.status == "outstanding" or \
-           (request_cart_to_modify.staff is not None and request_cart_to_modify.status == "active")
+    disbursements = [precheck_item(request, modification_type) for
+                     request in request_cart_to_modify.cart_disbursements.all()]
+    loans = [precheck_item(request, modification_type) for request in request_cart_to_modify.cart_loans.all()]
+    return not(False in disbursements or False in loans) and \
+        (request_cart_to_modify.status == "outstanding" or
+        (request_cart_to_modify.staff is not None and request_cart_to_modify.status == "active"))
+
+
+def subtract_item(request):
+    item = get_or_not_found(Item, pk=request.item.id)  # get item object based on item ID
+    item.quantity = item.quantity - request.quantity
+    item.save()
 
 
 def subtract_item_in_cart(request_cart_to_modify):
-    for request in request_cart_to_modify.cart_disbursements.all():
-        item = get_or_not_found(Item, pk=request.item.id)  # get item object based on item ID
-        item.quantity = item.quantity - request.quantity
-        item.save()
-    # TODO add another for loop for the loans
+    [subtract_item(request) for request in request_cart_to_modify.cart_disbursements.all()]
+    [subtract_item(request) for request in request_cart_to_modify.cart_loans.all()]
 
+
+def start_loan(request):
+    for loan in request.cart_loans.all():
+        loan.loaned_timestamp = datetime.now()
+        loan.save()

--- a/inventory_requests/serializers/DisbursementSerializer.py
+++ b/inventory_requests/serializers/DisbursementSerializer.py
@@ -2,7 +2,7 @@ from django.db.models import Q
 from rest_framework import serializers
 
 from inventoryProject.utility.queryset_functions import get_or_not_found
-from inventory_requests.models import Disbursement
+from inventory_requests.models import Disbursement, Loan
 from items.models import Item
 from inventory_requests.models import RequestCart
 from rest_framework.exceptions import MethodNotAllowed
@@ -35,5 +35,30 @@ class DisbursementSerializer(serializers.ModelSerializer):
             else:
                 disbursement = Disbursement.objects.create(item=item, cart=request_cart, **validated_data)
                 return disbursement
+        else:
+            raise MethodNotAllowed(self.create, "Item must be added to active cart")
+
+
+class LoanSerializer(serializers.ModelSerializer):
+    item = NestedItemSerializer(many=False, allow_null=False, read_only=True)
+    item_id = serializers.IntegerField(required=True, write_only=True)
+
+    class Meta:
+        model = Loan
+        fields = ('id', 'item_id', 'item', 'quantity', 'cart_id', 'loaned_timestamp', 'returned_timestamp')
+        extra_kwargs = {'quantity': {'required': True}}
+
+    def create(self, validated_data):
+        item_id = validated_data.pop('item_id')
+        user = self.context['request'].user
+        condition = (Q(owner=user) | Q(staff=user)) & Q(status='active')
+        if RequestCart.objects.filter(condition).exists():
+            request_cart = RequestCart.objects.get(condition)
+            item = get_or_not_found(Item, pk=item_id)
+            if request_cart.cart_loans.filter(item=item).exists():
+                raise MethodNotAllowed(self.create, "Item already exists in cart - cannot be added")
+            else:
+                loan = Loan.objects.create(item=item, cart=request_cart, **validated_data)
+                return loan
         else:
             raise MethodNotAllowed(self.create, "Item must be added to active cart")

--- a/inventory_requests/serializers/DisbursementSerializer.py
+++ b/inventory_requests/serializers/DisbursementSerializer.py
@@ -17,10 +17,11 @@ class NestedItemSerializer(serializers.ModelSerializer):
 class DisbursementSerializer(serializers.ModelSerializer):
     item = NestedItemSerializer(many=False, allow_null=False, read_only=True)
     item_id = serializers.IntegerField(required=True, write_only=True)
+    cart_owner = serializers.SerializerMethodField()
 
     class Meta:
         model = Disbursement
-        fields = ('id', 'item_id', 'item', 'quantity', 'cart_id')
+        fields = ('id', 'item_id', 'item', 'quantity', 'cart_id', 'cart_owner')
         extra_kwargs = {'quantity': {'required': True}}
 
     def create(self, validated_data):
@@ -38,14 +39,18 @@ class DisbursementSerializer(serializers.ModelSerializer):
         else:
             raise MethodNotAllowed(self.create, "Item must be added to active cart")
 
+    def get_cart_owner(self, obj):
+        return obj.cart.owner.username
+
 
 class LoanSerializer(serializers.ModelSerializer):
     item = NestedItemSerializer(many=False, allow_null=False, read_only=True)
     item_id = serializers.IntegerField(required=True, write_only=True)
+    cart_owner = serializers.SerializerMethodField()
 
     class Meta:
         model = Loan
-        fields = ('id', 'item_id', 'item', 'quantity', 'cart_id', 'loaned_timestamp', 'returned_timestamp')
+        fields = ('id', 'item_id', 'item', 'quantity', 'cart_id', 'cart_owner', 'loaned_timestamp', 'returned_timestamp')
         extra_kwargs = {'quantity': {'required': True}}
 
     def create(self, validated_data):
@@ -62,3 +67,6 @@ class LoanSerializer(serializers.ModelSerializer):
                 return loan
         else:
             raise MethodNotAllowed(self.create, "Item must be added to active cart")
+
+    def get_cart_owner(self, obj):
+        return obj.cart.owner.username

--- a/inventory_requests/serializers/RequestCartSerializer.py
+++ b/inventory_requests/serializers/RequestCartSerializer.py
@@ -1,19 +1,19 @@
 from rest_framework import serializers
 
 from inventory_requests.models import RequestCart
-from inventory_requests.serializers.DisbursementSerializer import DisbursementSerializer
+from inventory_requests.serializers.DisbursementSerializer import DisbursementSerializer, LoanSerializer
 
 
 class RequestCartSerializer(serializers.ModelSerializer):
     staff = serializers.SlugRelatedField(read_only=True, many=False, slug_field='username')
     owner = serializers.SlugRelatedField(read_only=True, many=False, slug_field='username')
     cart_disbursements = DisbursementSerializer(read_only=True, many=True)
-    # add loan serializer here
+    cart_loans = LoanSerializer(read_only=True, many=True)
     reason = serializers.CharField(required=True)
 
     class Meta:
         model = RequestCart
-        fields = ('id', 'owner', 'status', 'reason', 'cart_disbursements', 'timestamp', 'staff_timestamp',
+        fields = ('id', 'owner', 'status', 'reason', 'cart_disbursements', 'cart_loans', 'timestamp', 'staff_timestamp',
                   'staff_comment', 'staff')
 
     def create(self, validated_data):
@@ -21,3 +21,8 @@ class RequestCartSerializer(serializers.ModelSerializer):
         request_cart = RequestCart.objects.create(staff=user, **validated_data) if user.is_staff else \
             RequestCart.objects.create(owner=user, **validated_data)
         return request_cart
+
+
+class QuantitySerializer(serializers.Serializer):
+    type = serializers.ChoiceField(choices=['loan','disbursement'], required=True)
+    quantity = serializers.IntegerField(min_value=1, required=True)

--- a/inventory_requests/serializers/RequestCartSerializer.py
+++ b/inventory_requests/serializers/RequestCartSerializer.py
@@ -26,3 +26,9 @@ class RequestCartSerializer(serializers.ModelSerializer):
 class QuantitySerializer(serializers.Serializer):
     type = serializers.ChoiceField(choices=['loan','disbursement'], required=True)
     quantity = serializers.IntegerField(min_value=1, required=True)
+
+
+class RequestTypeSerializer(serializers.Serializer):
+    current_type = serializers.ChoiceField(choices=['loan', 'disbursement'], required=True)
+    pk = serializers.IntegerField(min_value=1, required=True)
+

--- a/inventory_requests/tests/test_loans_api.py
+++ b/inventory_requests/tests/test_loans_api.py
@@ -1,0 +1,196 @@
+# username and password to create superuser for testing
+import json
+from datetime import datetime, timezone, timedelta
+
+from django.contrib.auth.models import User
+from django.urls import reverse
+from oauth2_provider.admin import Application
+from oauth2_provider.models import AccessToken
+from oauth2_provider.settings import oauth2_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from inventory_requests.models import RequestCart, Loan
+from items.models import Item
+
+USERNAME = 'admin'
+PASSWORD = 'adminPassword'
+TEST_USERNAME = 'test_user'
+TEST_PASSWORD = 'testPassword'
+
+
+def equal_loans(test_client, loan_json, loan_id, cart_id=None):
+    loan = Loan.objects.get(pk=loan_id)
+    test_client.assertEqual(loan_json.get('item').get('name'), loan.item.name)
+    test_client.assertEqual(loan_json.get('quantity'), loan.quantity)
+    test_client.assertEqual(loan_json.get('cart_id'), loan.cart.id)
+    if cart_id is not None:
+        test_client.assertEqual(loan_json.get('cart_id'), cart_id)
+        test_client.assertEqual(loan.cart.id, cart_id)
+
+
+class LoansTestCases(APITestCase):
+    fixtures = ['requests_action.json']
+
+    def setUp(self):
+        self.admin = User.objects.create_superuser(USERNAME, 'test@test.com', PASSWORD)
+        self.basic_user = User.objects.create_user(TEST_USERNAME, 'test@test.com', TEST_PASSWORD)
+        self.application = Application(
+            name="Test Application",
+            redirect_uris="http://localhost",
+            user=self.admin,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        self.application.save()
+        self.tok = AccessToken.objects.create(
+            user=self.admin, token='1234567890',
+            application=self.application, scope='read write',
+            expires=datetime.now(timezone.utc) + timedelta(days=30)
+        )
+        self.test_application = Application(
+            name="Test User Application",
+            redirect_uris="http://localhost",
+            user=self.basic_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        self.test_application.save()
+        self.test_tok = AccessToken.objects.create(
+            user=self.basic_user, token='123490',
+            application=self.test_application, scope='read write',
+            expires=datetime.now(timezone.utc) + timedelta(days=30)
+        )
+        oauth2_settings._DEFAULT_SCOPES = ['read', 'write', 'groups']
+        self.item = Item.objects.create(name="test_item_1", quantity=10)
+        self.item_1 = Item.objects.create(name="test item 2", quantity=4)
+
+    def test_get_all_loans(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, reason="test shopping cart")
+        cart.cart_loans.create(item=self.item, quantity=2)
+        cart.cart_loans.create(item=self.item_1, quantity=4)
+        url = reverse('add-loan-to-cart')
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json.loads(str(response.content, 'utf-8'))['count'], Loan.objects.count())
+        loans_json = json.loads(str(response.content, 'utf-8'))['results']
+        [equal_loans(self, loan_json, loan_json['id']) for loan_json in loans_json]
+        cart.delete()
+
+    def test_create_loan_fail_inactive_cart(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, status='fulfilled', reason="test")
+        self.client.force_authenticate(user=self.basic_user, token=self.test_tok)
+        url = reverse('add-loan-to-cart')
+        data = {'item_id': self.item.id, 'quantity': 10}
+        response = self.client.post(path=url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(json.loads(str(response.content, 'utf-8'))['detail'], "Item must be added to active cart")
+        cart.delete()
+
+    def test_create_loan(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, reason="test shopping cart")
+        self.client.force_authenticate(user=self.basic_user, token=self.test_tok)
+        url = reverse('add-loan-to-cart')
+        data = {'item_id':self.item.id, 'quantity': 10}
+        response = self.client.post(path=url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        loan_json = json.loads(str(response.content, 'utf-8'))
+        equal_loans(test_client=self, loan_json=loan_json, loan_id=loan_json['id'], cart_id=cart.id)
+        cart.delete()
+
+    def test_delete_loan_inactive_cart(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, status='fulfilled', reason="test")
+        loan = Loan.objects.create(item=self.item_1, quantity=10, cart=cart)
+        self.client.force_authenticate(user=self.basic_user, token=self.test_tok)
+        url = reverse('delete-loan-from-cart',  kwargs={'pk': str(loan.id)})
+        response = self.client.delete(path=url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(json.loads(str(response.content, 'utf-8'))['detail'],
+                         "Cannot delete loan as request status: fulfilled != active")
+        self.assertTrue(Loan.objects.filter(pk=loan.id).exists())
+
+    def test_delete_loan(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, reason="active cart is lit")
+        loan = Loan.objects.create(item=self.item_1, quantity=10, cart=cart)
+        self.client.force_authenticate(user=self.basic_user, token=self.test_tok)
+        url = reverse('delete-loan-from-cart',  kwargs={'pk': str(loan.id)})
+        response = self.client.delete(path=url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Loan.objects.filter(pk=loan.id).exists())
+        cart.delete()
+
+    def test_return_loan_unfulfilled_cart(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, status='active', reason="test")
+        loan = Loan.objects.create(item=self.item_1, quantity=4, cart=cart, loaned_timestamp=datetime.now())
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse('return-loan-from-cart', kwargs={'pk': str(loan.id)})
+        response = self.client.patch(path=url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        detail_str = "Request needs to be fulfilled but is {status} and {item_name} cannot be " \
+                     "returned already by {user_name}".format(status=cart.status, item_name=self.item_1.name,
+                                                              user_name=self.basic_user.username)
+        self.assertEqual(json.loads(str(response.content, 'utf-8'))['detail'], detail_str)
+        self.assertTrue(Loan.objects.filter(pk=loan.id).exists())
+        cart.delete()
+
+    def test_return_loan(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, status="fulfilled", reason="return loan cart")
+        loan = Loan.objects.create(item=self.item_1, quantity=4, cart=cart, loaned_timestamp=datetime.now())
+        self.item_1.quantity = self.item_1.quantity - loan.quantity
+        self.item_1.save()
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse('return-loan-from-cart', kwargs={'pk': str(loan.id)})
+        response = self.client.patch(path=url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        loan_json = json.loads(str(response.content, 'utf-8'))
+        equal_loans(test_client=self, loan_json=loan_json, loan_id=loan_json['id'])
+        updated_loan = Loan.objects.get(pk=loan.id)
+        updated_item = Item.objects.get(pk=self.item_1.id)
+        self.assertEqual(updated_item.quantity, self.item_1.quantity + loan.quantity)
+        self.assertTrue(updated_loan.returned_timestamp > updated_loan.loaned_timestamp)
+        cart.delete()
+
+    def test_return_all_loans_fully_returned_fail(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, status="fulfilled", reason="return loan cart")
+        loan = Loan.objects.create(item=self.item, quantity=1, cart=cart, loaned_timestamp=datetime.now(),
+                                   returned_timestamp=datetime.now())
+        self.item.quantity = self.item.quantity - loan.quantity
+        self.item.save()
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse('return-all-loans-from-cart', kwargs={'pk': str(cart.id)})
+        response = self.client.patch(path=url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(json.loads(str(response.content, 'utf-8'))['detail'],
+                         "Request needs to be fulfilled but is fulfilled or Cart has been fully returned")
+
+    def test_return_all_loans(self):
+        cart = RequestCart.objects.create(owner=self.basic_user, status="fulfilled", reason="return loan cart")
+        loan = Loan.objects.create(item=self.item, quantity=1, cart=cart, loaned_timestamp=datetime.now())
+        loan_1 = Loan.objects.create(item=self.item_1, quantity=4, cart=cart, loaned_timestamp=datetime.now())
+        self.item.quantity = self.item.quantity - loan.quantity
+        self.item.save()
+        self.item_1.quantity = self.item_1.quantity - loan_1.quantity
+        self.item_1.save()
+        self.client.force_authenticate(user=self.admin, token=self.tok)
+        url = reverse('return-all-loans-from-cart', kwargs={'pk': str(cart.id)})
+        response = self.client.patch(path=url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cart_id = json.loads(str(response.content, 'utf-8'))['id']
+        loans_json = json.loads(str(response.content, 'utf-8'))['cart_loans']
+        [equal_loans(test_client=self, loan_json=loan_json, loan_id=loan_json['id'], cart_id=cart_id)
+         for loan_json in loans_json]
+        [self.assertTrue(Loan.objects.get(pk=loan_json['id']).returned_timestamp is not None)
+         for loan_json in loans_json]
+        cart.delete()
+
+
+
+
+
+
+
+
+
+
+

--- a/inventory_requests/tests/test_request_cart_api.py
+++ b/inventory_requests/tests/test_request_cart_api.py
@@ -645,7 +645,7 @@ class PatchRequestTestCases(APITestCase):
         response = self.client.patch(path=url, data=data)
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertEqual(json.loads(str(response.content, 'utf-8'))['detail']
-                         , "Cannot disburse due to insufficient items")
+                         , "Cannot dispense due to insufficient items")
 
 
 class ConvertRequestTypeTestCase(APITestCase):

--- a/inventory_requests/tests/test_request_cart_api.py
+++ b/inventory_requests/tests/test_request_cart_api.py
@@ -467,8 +467,7 @@ class PatchRequestTestCases(APITestCase):
         item_with_one_tag = Item.objects.create(name="oscilloscope", quantity=3, model_number="48979",
                                                 description="oscilloscope")
         item_with_one_tag.tags.create(tag="test")
-        request_to_approve = RequestCart.objects.create(owner=self.admin, status="outstanding", reason="test_cart",
-                                                        staff_comment="this is an admin comment", staff=self.admin)
+        request_to_approve = RequestCart.objects.create(owner=self.admin, status="outstanding", reason="test_cart")
         disbursement = Disbursement.objects.create(item=item_with_one_tag, quantity=2, cart=request_to_approve)
         data = {'id': request_to_approve.id, 'staff_comment': 'testing approve request'}
         url = reverse('approve-request-cart', kwargs={'pk': str(request_to_approve.id)})
@@ -515,8 +514,7 @@ class PatchRequestTestCases(APITestCase):
         item_with_one_tag = Item.objects.create(name="oscilloscope", quantity=3, model_number="48979",
                                                 description="oscilloscope")
         item_with_one_tag.tags.create(tag="test")
-        request_to_deny = RequestCart.objects.create(owner=self.admin, status="outstanding", reason="test cart",
-                                                     staff_comment="this is an admin comment", staff=self.admin)
+        request_to_deny = RequestCart.objects.create(owner=self.admin, status="outstanding", reason="test cart")
         Disbursement.objects.create(item=item_with_one_tag, quantity=4, cart=request_to_deny)
         data = {'id': request_to_deny.id, 'staff_comment': 'testing deny request'}
         url = reverse('deny-request-cart', kwargs={'pk': str(request_to_deny.id)})
@@ -533,8 +531,7 @@ class PatchRequestTestCases(APITestCase):
         item_with_one_tag = Item.objects.create(name="oscilloscope", quantity=3, model_number="48979",
                                                 description="oscilloscope")
         item_with_one_tag.tags.create(tag="test")
-        request_to_deny = RequestCart.objects.create(owner=self.admin, status="cancelled", reason="test cart",
-                                                     staff_comment="this is an admin comment", staff=self.admin)
+        request_to_deny = RequestCart.objects.create(owner=self.admin, status="cancelled", reason="test cart")
         Disbursement.objects.create(item=item_with_one_tag, quantity=2, cart=request_to_deny)
         data = {'id': request_to_deny.id, 'admin_comment': 'testing deny request'}
         url = reverse('deny-request-cart', kwargs={'pk': str(request_to_deny.id)})
@@ -565,8 +562,7 @@ class PatchRequestTestCases(APITestCase):
         item_with_one_tag = Item.objects.create(name="oscilloscope", quantity=3, model_number="48979",
                                                 description="oscilloscope")
         item_with_one_tag.tags.create(tag="test")
-        request_to_cancel = RequestCart.objects.create(owner=self.admin, status="outstanding", reason="test cart",
-                                                       staff_comment="this is an admin comment", staff=self.admin)
+        request_to_cancel = RequestCart.objects.create(owner=self.admin, status="outstanding", reason="test cart")
         Disbursement.objects.create(item=item_with_one_tag, quantity=2, cart=request_to_cancel)
         data = {'id': request_to_cancel.id, 'comment': 'testing cancellation of request, should not work'}
         url = reverse('cancel-request-cart', kwargs={'pk': str(request_to_cancel.id)})

--- a/inventory_requests/tests/test_request_cart_api.py
+++ b/inventory_requests/tests/test_request_cart_api.py
@@ -425,7 +425,7 @@ class PatchRequestTestCases(APITestCase):
         request_to_modify = RequestCart.objects.create(owner=self.admin, status="active", reason="test cart",
                                                        staff_comment="this is an admin comment", staff=self.admin)
         disbursement = Disbursement.objects.create(item=item_with_one_tag, quantity=1, cart=request_to_modify)
-        data = {'item_id': item_with_one_tag.id, 'quantity': 2}
+        data = {'type': 'disbursement', 'quantity': 2}
         url = reverse('modify-quantity-requested', kwargs={'pk': str(disbursement.id)})
         response = self.client.patch(url, data, format='json')
         updated_disbursement = Disbursement.objects.get(pk=disbursement.id)
@@ -440,7 +440,7 @@ class PatchRequestTestCases(APITestCase):
         request_to_modify = RequestCart.objects.create(owner=self.admin, status="outstanding", reason="lol_cart",
                                                        staff_comment="this is an admin comment", staff=self.admin)
         disbursement = Disbursement.objects.create(item=item_with_one_tag, quantity=1, cart=request_to_modify)
-        data = {'item_id': item_with_one_tag.id, 'quantity': 2}
+        data = {'type': 'disbursement', 'quantity': 2}
         url = reverse('modify-quantity-requested', kwargs={'pk': str(disbursement.id)})
         response = self.client.patch(url, data, format='json')
         updated_disbursement = Disbursement.objects.get(pk=disbursement.id)
@@ -455,7 +455,7 @@ class PatchRequestTestCases(APITestCase):
         request_to_modify = RequestCart.objects.create(owner=self.admin, status="active", reason="test shopping cart",
                                                        staff_comment="this is an admin comment", staff=self.admin)
         disbursement = Disbursement.objects.create(item=item_with_one_tag, quantity=1, cart=request_to_modify)
-        data = {'item_id': item_with_one_tag.id, 'quantity': -5}
+        data = {'type': 'disbursement', 'quantity': -5}
         url = reverse('modify-quantity-requested', kwargs={'pk': str(disbursement.id)})
         response = self.client.patch(url, data, format='json')
         updated_disbursement = Disbursement.objects.get(pk=disbursement.id)

--- a/inventory_requests/urls.py
+++ b/inventory_requests/urls.py
@@ -5,7 +5,7 @@ from inventory_requests.views.RequestCartList import RequestCartList
 from inventory_requests.views.ActiveSendDetailedRequestCart import ViewDetailedRequestCart, ActiveRequestCart, SendCart
 from inventory_requests.views.CreateDeleteModifyDisbursement import CreateDisbursement, DeleteDisbursement
 from inventory_requests.views.ModifyRequestCart import ApproveRequestCart, DenyRequestCart, CancelRequestCart, \
-    FulfillRequestCart, DispenseRequestCart, ModifyQuantityRequested
+    FulfillRequestCart, DispenseRequestCart, ModifyQuantityRequested, ConvertRequestType
 
 urlpatterns = [
     url(r'^$', RequestCartList.as_view(), name='request-cart-list'),
@@ -25,4 +25,5 @@ urlpatterns = [
     url(r'^loan/deleteItem/(?P<pk>[0-9]+)/$', DeleteLoan.as_view(), name='delete-loan-from-cart'),
     url(r'^loan/returnItem/(?P<pk>[0-9]+)/$', ReturnLoan.as_view(), name='return-loan-from-cart'),
     url(r'^returnAllLoans/(?P<pk>[0-9]+)/$', ReturnAllLoans.as_view(), name='return-all-loans-from-cart'),
+    url(r'^convertRequestType/$', ConvertRequestType.as_view(), name='convert-request-type')
 ]

--- a/inventory_requests/urls.py
+++ b/inventory_requests/urls.py
@@ -1,17 +1,18 @@
 from django.conf.urls import url
 
+from inventory_requests.views.CreateDeleteModifyLoan import CreateLoan, DeleteLoan, ReturnLoan, ReturnAllLoans
 from inventory_requests.views.RequestCartList import RequestCartList
 from inventory_requests.views.ActiveSendDetailedRequestCart import ViewDetailedRequestCart, ActiveRequestCart, SendCart
-from inventory_requests.views.CreateDeleteModifyDisbursement import CreateDisbursement, DeleteDisbursement, ModifyQuantityRequested
+from inventory_requests.views.CreateDeleteModifyDisbursement import CreateDisbursement, DeleteDisbursement
 from inventory_requests.views.ModifyRequestCart import ApproveRequestCart, DenyRequestCart, CancelRequestCart, \
-    FulfillRequestCart, DispenseRequestCart
+    FulfillRequestCart, DispenseRequestCart, ModifyQuantityRequested
 
 urlpatterns = [
     url(r'^$', RequestCartList.as_view(), name='request-cart-list'),
     url(r'^(?P<pk>[0-9]+)$', ViewDetailedRequestCart.as_view(), name='detailed-request-cart'),
     url(r'^active/$', ActiveRequestCart.as_view(), name='active-cart'),
-    url(r'^addItem/$', CreateDisbursement.as_view(), name='add-to-cart'),
-    url(r'^deleteItem/(?P<pk>[0-9]+)/$', DeleteDisbursement.as_view(), name='delete-from-cart'),
+    url(r'^disbursement/$', CreateDisbursement.as_view(), name='add-to-cart'),
+    url(r'^disbursement/deleteItem/(?P<pk>[0-9]+)/$', DeleteDisbursement.as_view(), name='delete-from-cart'),
     url(r'^send/(?P<pk>[0-9]+)/$', SendCart.as_view(), name='send-cart'),
     url(r'^modifyQuantityRequested/(?P<pk>[0-9]+)/$', ModifyQuantityRequested.as_view(),
         name='modify-quantity-requested'),
@@ -20,4 +21,8 @@ urlpatterns = [
     url(r'^deny/(?P<pk>[0-9]+)/$', DenyRequestCart.as_view(), name='deny-request-cart'),
     url(r'^dispense/(?P<pk>[0-9]+)/$', DispenseRequestCart.as_view(), name='dispense-request-cart'),
     url(r'^fulfill/(?P<pk>[0-9]+)/$', FulfillRequestCart.as_view(), name='fulfill-request-cart'),
+    url(r'^loan/$', CreateLoan.as_view(), name='add-loan-to-cart'),
+    url(r'^loan/deleteItem/(?P<pk>[0-9]+)/$', DeleteLoan.as_view(), name='delete-loan-from-cart'),
+    url(r'^loan/returnItem/(?P<pk>[0-9]+)/$', ReturnLoan.as_view(), name='return-loan-from-cart'),
+    url(r'^returnAllLoans/(?P<pk>[0-9]+)/$', ReturnAllLoans.as_view(), name='return-all-loans-from-cart'),
 ]

--- a/inventory_requests/views/ActiveSendDetailedRequestCart.py
+++ b/inventory_requests/views/ActiveSendDetailedRequestCart.py
@@ -46,7 +46,7 @@ class SendCart(APIView):
         request_cart = get_or_not_found(RequestCart, pk=pk)
         if request_cart.owner is None and request_cart.staff is not None:
             raise MethodNotAllowed(detail="This is a Staff Cart, please use the dispense method", method=self.patch)
-        if request_cart.cart_disbursements.count() == 0:
+        if request_cart.cart_disbursements.count() == 0 and request_cart.cart_loans.count() == 0:
             raise MethodNotAllowed(detail="Cannot submit empty request cart", method=self.patch)
         if request_cart.status == "active":
             request_cart.status = "outstanding"

--- a/inventory_requests/views/CreateDeleteModifyDisbursement.py
+++ b/inventory_requests/views/CreateDeleteModifyDisbursement.py
@@ -15,7 +15,7 @@ class CreateDisbursement(generics.ListCreateAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = DisbursementSerializer
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
-    filter_fields = ('cart__status',)
+    filter_fields = ('cart__status', 'item__name', 'cart__owner__username')
 
     def get_queryset(self):
         user = self.request.user

--- a/inventory_requests/views/CreateDeleteModifyDisbursement.py
+++ b/inventory_requests/views/CreateDeleteModifyDisbursement.py
@@ -1,21 +1,25 @@
+import django_filters
 from rest_framework import generics
 from rest_framework import status
+from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from inventoryProject.utility.queryset_functions import get_or_not_found
 from inventory_requests.models import Disbursement
-from inventory_requests.models import RequestCart
-from rest_framework.exceptions import MethodNotAllowed, NotFound, ParseError
-
 from inventory_requests.serializers.DisbursementSerializer import DisbursementSerializer
 
 
-class CreateDisbursement(generics.CreateAPIView):
+class CreateDisbursement(generics.ListCreateAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = DisbursementSerializer
-    queryset = Disbursement.objects.all()
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filter_fields = ('cart__status',)
+
+    def get_queryset(self):
+        user = self.request.user
+        return Disbursement.objects.all() if user.is_staff else Disbursement.objects.filter(cart__owner=user)
 
 
 class DeleteDisbursement(APIView):
@@ -25,28 +29,8 @@ class DeleteDisbursement(APIView):
         disbursement = get_or_not_found(Disbursement, pk=pk)
         user = self.request.user
         if disbursement.cart.status == 'active' and (disbursement.cart.owner == user or
-                                                             disbursement.cart.staff == user):
+                                                     disbursement.cart.staff == user):
             disbursement.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
         else:
             raise MethodNotAllowed("Cannot delete disbursement from request cart that is not active")
-
-
-class ModifyQuantityRequested(generics.UpdateAPIView):
-    queryset = Disbursement.objects.all()
-    serializer_class = DisbursementSerializer
-    permission_classes = [IsAuthenticated]
-
-    def patch(self, request, *args, **kwargs):
-        quantity = request.data.get('quantity')
-        if quantity is None:
-            raise MethodNotAllowed(self.patch, detail='Quantity required')
-        return self.partial_update(request, *args, **kwargs)
-
-    def perform_update(self, serializer):
-        request_cart = self.get_object().cart
-        if request_cart.status != 'active':
-            raise MethodNotAllowed(self.patch, "Item with quantity to modify must be part of active cart")
-        if serializer.validated_data.get('quantity') <= 0:
-            raise ParseError(detail="Quantity must be greater than 0")
-        serializer.save()

--- a/inventory_requests/views/CreateDeleteModifyLoan.py
+++ b/inventory_requests/views/CreateDeleteModifyLoan.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+
+import django_filters
+from rest_framework import generics
+from rest_framework import status
+from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from inventoryProject.permissions import IsStaffUser
+from inventoryProject.utility.queryset_functions import get_or_not_found
+from inventory_requests.business_logic.loan_logic import return_loan_logic
+from inventory_requests.models import Loan, RequestCart
+from inventory_requests.serializers.DisbursementSerializer import LoanSerializer
+from inventory_requests.serializers.RequestCartSerializer import RequestCartSerializer
+from items.models import Item
+
+
+class CreateLoan(generics.ListCreateAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = LoanSerializer
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filter_fields = ('cart__status',)
+
+    def get_queryset(self):
+        user = self.request.user
+        return Loan.objects.all() if user.is_staff else Loan.objects.filter(cart__owner=user)
+
+
+class DeleteLoan(generics.DestroyAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = LoanSerializer
+    queryset = Loan.objects.all()
+
+    def perform_destroy(self, instance):
+        user = self.request.user
+        request = instance.cart
+        if request.status == 'active' and (request.owner == user or user.is_staff):
+            instance.delete()
+        else:
+            detail_str = "Cannot delete loan as request status: {status} != active".format(status=request.status)
+            raise MethodNotAllowed(method=self.delete, detail=detail_str)
+
+
+class ReturnLoan(APIView):
+    permission_classes = [IsStaffUser]
+
+    def patch(self, request, pk):
+        loan = get_or_not_found(Loan, pk=pk)
+        if loan.cart.status == 'fulfilled' and return_loan_logic(loan):
+            return Response(data=LoanSerializer(loan).data, status=status.HTTP_200_OK)
+        detail_str = "Request needs to be fulfilled but is {status} and {item_name} cannot be " \
+                     "returned already by {user_name}".format(status=loan.cart.status, item_name=loan.item.name,
+                                                              user_name=loan.cart.owner.username)
+        raise MethodNotAllowed(method=self.patch, detail=detail_str)
+
+
+class ReturnAllLoans(APIView):
+    permission_classes = [IsStaffUser]
+
+    def patch(self, request, pk):
+        cart = get_or_not_found(RequestCart, pk=pk)
+        if cart.status == 'fulfilled' and cart.cart_loans.filter(returned_timestamp__isnull=True).exists():
+            [return_loan_logic(loan=loan) for loan in cart.cart_loans.all()]
+            updated_cart = get_or_not_found(RequestCart, pk=pk)
+            return Response(data=RequestCartSerializer(updated_cart).data, status=status.HTTP_200_OK)
+        detail_str = "Request needs to be fulfilled but is {status} or Cart has been fully returned"\
+            .format(status=cart.status)
+        raise MethodNotAllowed(method=self.patch, detail=detail_str)
+

--- a/inventory_requests/views/CreateDeleteModifyLoan.py
+++ b/inventory_requests/views/CreateDeleteModifyLoan.py
@@ -21,7 +21,7 @@ class CreateLoan(generics.ListCreateAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = LoanSerializer
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
-    filter_fields = ('cart__status',)
+    filter_fields = ('cart__status', 'item__name', 'cart__owner__username')
 
     def get_queryset(self):
         user = self.request.user

--- a/inventory_requests/views/ModifyRequestCart.py
+++ b/inventory_requests/views/ModifyRequestCart.py
@@ -31,9 +31,8 @@ class ApproveRequestCart(APIView):
 
     def patch(self, request, pk, format=None):
         request_cart_to_approve = get_or_not_found(RequestCart, pk=pk)
-        cart_status = "approved"
-        if modify_request_cart_logic.can_approve_disburse_request_cart(request_cart_to_approve, cart_status):
-            request_cart_to_approve.status = cart_status
+        if modify_request_cart_logic.can_approve_disburse_request_cart(request_cart_to_approve):
+            request_cart_to_approve.status = "approved"
             serializer = ApproveDenySerializer(request_cart_to_approve, data=request.data)
             if serializer.is_valid():
                 serializer.save(staff=request.user, staff_timestamp=datetime.now())
@@ -134,8 +133,8 @@ class DispenseRequestCart(generics.UpdateAPIView):
     def perform_update(self, serializer):
         request_cart = self.get_object()
         get_or_not_found(User, pk=serializer.validated_data.get('owner_id'))
-        if not modify_request_cart_logic.can_approve_disburse_request_cart(request_cart, 'disburse'):
-            detail_str = 'Cannot disburse due to insufficient items' if request_cart.status == 'active' else \
+        if not modify_request_cart_logic.can_approve_disburse_request_cart(request_cart):
+            detail_str = 'Cannot dispense due to insufficient items' if request_cart.status == 'active' else \
                 'Cart needs to be active'
             raise MethodNotAllowed(method=self.patch, detail=detail_str)
         modify_request_cart_logic.subtract_item_in_cart(request_cart)


### PR DESCRIPTION
Created loans:-
- create loans
- delete loans
- return loans (adds back to active item quantity)
- modified the ModifyQuantityMethod to work for both loans and disbursements
- modified the send cart method for dispense and plebian to support checks for loans

CHANGED API FOR CREATE DISBURSEMENT to /api/request/disbursement/

1. Get all loans
GET /api/request/loan/ HTTP/1.1
Can filter by 'cart__status', 'item__name', 'cart__owner__username','returned'
returned is either true or false
Response:
```json
{
  "count": 2,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 4,
      "item": {
        "id": 5,
        "name": "iPhone 7",
        "quantity": 18
      },
      "quantity": 3,
      "cart_id": 12,
      "loaned_timestamp": "2017-03-18T20:26:47.451709Z",
      "returned_timestamp": "2017-03-18T20:28:03.874267Z"
    },
    {
      "id": 2,
      "item": {
        "id": 5,
        "name": "iPhone 7",
        "quantity": 18
      },
      "quantity": 3,
      "cart_id": 11,
      "loaned_timestamp": "2017-03-17T06:13:08.205724Z",
      "returned_timestamp": "2017-03-17T06:14:43.952348Z"
    }
  ]
}
```

2. Create a loan 
POST /api/request/loan/addItem/ HTTP/1.1
Request:
```json
{
	"item_id": 5,
	"quantity": 3
}
```
Response:
```json
{
    "id": 5,
    "item": {
        "id": 5,
        "name": "iPhone 7",
        "quantity": 18
    },
    "quantity": 3,
    "cart_id": 13,
    "loaned_timestamp": null,
    "returned_timestamp": null
}
```

3. Delete a loan
DELETE /api/request/loan/deleteItem/5 HTTP/1.1

Returns HTTP_204_NO_CONTENT on success

4. Return Loan
PATCH /api/request/loan/returnItem/6/ HTTP/1.1
Cart must be fulfilled already
Response:
```json
{
    "id": 6,
    "item": {
        "id": 5,
        "name": "iPhone 7",
        "quantity": 15
    },
    "quantity": 3,
    "cart_id": 13,
    "loaned_timestamp": "2017-03-18T20:43:13.042918Z",
    "returned_timestamp": "2017-03-18T16:43:32.183303"
}
```

5. Return All Loans
PATCH /api/request/returnAllLoans/16/ HTTP/1.1
This returns the entire cart
Response:
```json
{
    "id": 16,
    "owner": "plebian",
    "status": "fulfilled",
    "reason": "we put in random reason",
    "cart_disbursements": [],
    "cart_loans": [
        {
            "id": 9,
            "item": {
                "id": 5,
                "name": "iPhone 7",
                "quantity": 15
            },
            "quantity": 3,
            "cart_id": 16,
            "loaned_timestamp": "2017-03-19T17:53:40.329680Z",
            "returned_timestamp": "2017-03-19T17:53:56.556661Z"
        }
    ],
    "timestamp": "2017-03-19T17:53:01.914821Z",
    "staff_timestamp": "2017-03-19T17:53:40.283118Z",
    "staff_comment": "lit",
    "staff": "staff"
}
```

6. Modify Quantity of Disbursement/Loan
PATCH /api/request/modifyQuantityRequested/7/ HTTP/1.1
Type can be ['loan','disbursement']
Request:
```json
{
	"type": "loan",
	"quantity": 1
}
```
Response:
```json
{
    "id": 7,
    "item": {
        "id": 5,
        "name": "iPhone 7",
        "quantity": 18
    },
    "quantity": 1,
    "cart_id": 14,
    "loaned_timestamp": null,
    "returned_timestamp": null
}
```

7. Convert Request Type
POST /api/request/convertRequestType/ HTTP/1.1
Request:
```json
{
	"current_type": "disbursement",
	"pk": 10
}
```
Response:
```json
{
  "id": 11,
  "item": {
    "id": 7,
    "name": "Samsung Galaxy Note",
    "quantity": 9000
  },
  "quantity": 3,
  "cart_id": 7,
  "cart_owner": "panda",
  "loaned_timestamp": "2017-03-16T19:11:49.825038Z",
  "returned_timestamp": null
}
```
current_type = ['loan','disbursement']
pk = pk of the current_type
They are response are both the same (except if current_type is loan, then there is no loaned_timestamp or returned_timestamp). 


